### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ ECMobile
 
 [ECMobile](http://www.ecmobile.cn) 是基于 [ECShop](http://www.ecshop.com) 的手机商城客户端，包括iOS、Android、PHP三个平台源代码及框架已开放下载！
 
-#####支持开源及后续版本更新，请FORK和STAR，感谢您的支持！
+##### 支持开源及后续版本更新，请FORK和STAR，感谢您的支持！
 
 1. iOS: [https://github.com/GeekZooStudio/ECMobile_iOS](https://github.com/GeekZooStudio/ECMobile_iOS)
 2. Android: [https://github.com/GeekZooStudio/ECMobile_Android](https://github.com/GeekZooStudio/ECMobile_Android)

--- a/doc/ECMobile_Android.md
+++ b/doc/ECMobile_Android.md
@@ -1,4 +1,4 @@
-#修改工程
+# 修改工程
 
 1. 打开工程
 2. 找到ECMobileAppConst.java，修改代码 SERVER_PRODUCTION
@@ -124,7 +124,7 @@ public static String getPushSecKey(Context context)
 }		
 </pre>
 
-#联系方式
+# 联系方式
 
 官方论坛：http://bbs.ecmobile.cn/    
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
